### PR TITLE
feat: 면접체질 테스트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.springframework.boot' version '3.3.1'
+	id 'io.spring.dependency-management' version '1.1.5'
 }
 
 group = 'com.upbeat'
@@ -47,6 +47,8 @@ dependencies {
 
 	implementation 'org.slf4j:slf4j-api'
 	implementation 'org.springframework.boot:spring-boot-starter-logging'
+
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.0.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
 	implementation 'org.slf4j:slf4j-api'
 	implementation 'org.springframework.boot:spring-boot-starter-logging'
+
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/controller/OptionController.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/controller/OptionController.java
@@ -1,0 +1,24 @@
+package com.upbeat.upbeat.domain.interviewtest.controller;
+
+import com.upbeat.upbeat.domain.interviewtest.dto.OptionResponseDto;
+import com.upbeat.upbeat.domain.interviewtest.service.OptionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController//api 서버 역할을 한다. 반환값을 view로 랜더링하지 않고 json형태로 응답하게 해준다.
+@RequiredArgsConstructor//final 필드나 @nonnull필드를 생성자 파라미터로 갖는 생성자를 자동 생성해준다.
+@RequestMapping("/api/options")
+public class OptionController {
+    private final OptionService optionService;//서비스 계층과 연결되는 필드
+
+    //특정 질문 id에 대한 보기 목록을 반환합니다. ex) api/options/question/1을 요청하면 질문에 해당하는 보기 2개가 나옵니다.
+    @GetMapping("/question/{questionId}")//옵션에 해당하는 질문
+    public List<OptionResponseDto> getOptionByQuestionId(@PathVariable Long questionId) {//questionid를 기준으로 옵션들을 조회해서 list형태로 반환한다.
+        return optionService.getOptionsByQuestionId(questionId);
+    }
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/controller/QuestionController.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/controller/QuestionController.java
@@ -1,0 +1,28 @@
+package com.upbeat.upbeat.domain.interviewtest.controller;
+
+import com.upbeat.upbeat.domain.interviewtest.dto.QuestionResponseDto;
+import com.upbeat.upbeat.domain.interviewtest.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/questions")
+public class QuestionController {
+
+    private final QuestionService questionService;//서비스 계층과 연결되는 필드
+
+    @GetMapping//전체 질문을 조회합니다.
+    public List<QuestionResponseDto> getAllQuestions() {
+        return questionService.getAllQuestions();
+    }
+    @GetMapping("/{id}")//특정 질문 id로 질문 상세조회합니다. 질문 id는 1~10입니다.
+    public QuestionResponseDto getQuestionById(@PathVariable Long id) {
+        return questionService.getQuestionById(id);
+    }
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/controller/ResultTypeController.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/controller/ResultTypeController.java
@@ -1,0 +1,21 @@
+package com.upbeat.upbeat.domain.interviewtest.controller;
+
+import com.upbeat.upbeat.domain.interviewtest.dto.ResultTypeResponseDto;
+import com.upbeat.upbeat.domain.interviewtest.service.ResultTypeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/results")
+public class ResultTypeController {
+    private final ResultTypeService resultTypeService;
+
+    @GetMapping("/{code}")//프론트에서 모든 결과유형 보기 기능시 필요할 수도 있어서 만들어놨음
+    public ResultTypeResponseDto getResult(@PathVariable String code) {
+        return resultTypeService.getResultByTypeCode(code);
+    }
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/controller/UserAnswerController.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/controller/UserAnswerController.java
@@ -1,0 +1,42 @@
+package com.upbeat.upbeat.domain.interviewtest.controller;
+
+import com.upbeat.upbeat.domain.interviewtest.dto.ResultTypeResponseDto;
+import com.upbeat.upbeat.domain.interviewtest.dto.UserAnswerRequestDto;
+import com.upbeat.upbeat.domain.interviewtest.dto.UserAnswerResponseDto;
+import com.upbeat.upbeat.domain.interviewtest.entity.UserAnswer;
+import com.upbeat.upbeat.domain.interviewtest.service.UserAnswerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user-answers")
+public class UserAnswerController {
+    private final UserAnswerService userAnswerService;
+
+    //사용자 응답 저장 api
+    @PostMapping
+    public void submitAnswer(@RequestBody UserAnswerRequestDto dto) {
+        userAnswerService.saveUserAnswer(dto);
+    }
+
+    //사용자 응답 전체조회 api
+    @GetMapping("/{userId}")
+    public List<UserAnswerResponseDto> getUserAnswers(@PathVariable Long userId) {
+        return userAnswerService.getUserAnswerDtos(userId);
+    }
+    // 사용자 응답 기반 결과 유형 반환 API
+    @GetMapping("/result/{userId}")
+    public ResultTypeResponseDto getUserResult(@PathVariable Long userId) {
+        return userAnswerService.getUserResultType(userId);
+    }
+    //type유형 반환으로 인해 새로 추가한 url
+    @GetMapping("/result/redirect/{userId}")
+    public Map<String, String> getRedirectUrl(@PathVariable Long userId) {
+        return userAnswerService.getRedirectUrlByUserResult(userId);
+    }
+
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/controller/UserAnswerController.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/controller/UserAnswerController.java
@@ -5,7 +5,9 @@ import com.upbeat.upbeat.domain.interviewtest.dto.UserAnswerRequestDto;
 import com.upbeat.upbeat.domain.interviewtest.dto.UserAnswerResponseDto;
 import com.upbeat.upbeat.domain.interviewtest.entity.UserAnswer;
 import com.upbeat.upbeat.domain.interviewtest.service.UserAnswerService;
+import com.upbeat.upbeat.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,8 +21,10 @@ public class UserAnswerController {
 
     //사용자 응답 저장 api
     @PostMapping
-    public void submitAnswer(@RequestBody UserAnswerRequestDto dto) {
-        userAnswerService.saveUserAnswer(dto);
+    public UserAnswerResponseDto submitAnswer(@RequestBody UserAnswerRequestDto dto,
+                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUser().getId();
+        return userAnswerService.saveUserAnswer(dto, userId);
     }
 
     //사용자 응답 전체조회 api

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/OptionResponseDto.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/OptionResponseDto.java
@@ -1,0 +1,14 @@
+//질문에 대한 보기(옵션) 정보를 클라이언트에 전달하기 위함
+package com.upbeat.upbeat.domain.interviewtest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OptionResponseDto {
+    private Long id;
+    private String label;
+    private String content;
+    private String typeCode;
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/QuestionResponseDto.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/QuestionResponseDto.java
@@ -1,0 +1,24 @@
+//테스트 결과를 나타냄
+package com.upbeat.upbeat.domain.interviewtest.dto;
+
+import com.upbeat.upbeat.domain.interviewtest.entity.Question;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class QuestionResponseDto {
+    private Long id;
+    private String question;
+    private List<OptionResponseDto> options;
+
+    public static QuestionResponseDto from(Question question) {
+        List<OptionResponseDto> options = question.getOptions().stream()
+                .map(opt -> new OptionResponseDto(opt.getId(), opt.getLabel(), opt.getContent(), opt.getTypeCode()))
+                .toList();
+
+        return new QuestionResponseDto(question.getId(), question.getQuestion(), options);
+    }
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/ResultTypeResponseDto.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/ResultTypeResponseDto.java
@@ -1,0 +1,12 @@
+//특정 질문에 대해 선택한 답변을 백엔드로 전달할 때 사용
+package com.upbeat.upbeat.domain.interviewtest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResultTypeResponseDto {
+    private String name;
+    private String description;
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/UserAnswerRequestDto.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/UserAnswerRequestDto.java
@@ -1,0 +1,13 @@
+//특정 질문에 대해 선택한 답변을 백엔드로 전달할 때 사용
+package com.upbeat.upbeat.domain.interviewtest.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserAnswerRequestDto {
+    private Long userId;
+    private Long questionId;
+    private Long optionId;
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/UserAnswerRequestDto.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/UserAnswerRequestDto.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class UserAnswerRequestDto {
-    private Long userId;
+    //private Long userId;
     private Long questionId;
     private Long optionId;
 }

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/UserAnswerResponseDto.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/dto/UserAnswerResponseDto.java
@@ -1,0 +1,29 @@
+package com.upbeat.upbeat.domain.interviewtest.dto;
+
+import com.upbeat.upbeat.domain.interviewtest.entity.UserAnswer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserAnswerResponseDto {
+    private Long id;
+    private Long userId;
+    private Long questionId;
+    private String questionContent;
+    private Long optionId;
+    private String optionLabel;
+    private String optionContent;
+
+    public static UserAnswerResponseDto from(UserAnswer ua) {
+        return new UserAnswerResponseDto(
+                ua.getId(),
+                ua.getUserId(),
+                ua.getQuestion().getId(),
+                ua.getQuestion().getQuestion(),
+                ua.getOption().getId(),
+                ua.getOption().getLabel(),
+                ua.getOption().getContent()
+        );
+    }
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/entity/Option.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/entity/Option.java
@@ -1,0 +1,27 @@
+//응답
+package com.upbeat.upbeat.domain.interviewtest.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="options")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor
+public class Option {
+    @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    private Long id;
+
+    private String label; // 'A' 혹은 'B' 구분
+
+    private String content; // 보기 텍스트
+
+    private String typeCode; // 유형 분류용 태그
+
+    @ManyToOne
+    @JoinColumn(name="question_id")
+    private Question question;
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/entity/Question.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/entity/Question.java
@@ -1,0 +1,23 @@
+//질문
+package com.upbeat.upbeat.domain.interviewtest.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "test_question")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String question;
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)//Option엔티티에서 관계의 주인이 question이다. cascade로 인해 Question삭제시 관련 option도 삭제 된다.
+    private List<Option> options = new ArrayList<>();
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/entity/ResultType.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/entity/ResultType.java
@@ -1,0 +1,19 @@
+//결과유형반환
+package com.upbeat.upbeat.domain.interviewtest.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="result_types")
+@Getter
+@NoArgsConstructor
+public class ResultType {
+    @Id
+    private String code;// Type1, Type2등등 분류하는 코드
+
+    private String name;//두루뭉술 낭만가형
+
+    private String description;//유형 설명
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/entity/UserAnswer.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/entity/UserAnswer.java
@@ -1,0 +1,29 @@
+//유저답변 저장
+package com.upbeat.upbeat.domain.interviewtest.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "user_answers")
+public class UserAnswer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;//사용자 식별자
+
+    @ManyToOne
+    @JoinColumn(name="question_id")
+    private Question question;
+
+    @ManyToOne
+    @JoinColumn(name="option_id")
+    private Option option;
+
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/repository/OptionRepository.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/repository/OptionRepository.java
@@ -1,0 +1,10 @@
+package com.upbeat.upbeat.domain.interviewtest.repository;
+
+import com.upbeat.upbeat.domain.interviewtest.entity.Option;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OptionRepository extends JpaRepository<Option, Long> {
+    List<Option> findByQuestionId(Long questionId);
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/repository/QuestionRepository.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/repository/QuestionRepository.java
@@ -1,0 +1,7 @@
+package com.upbeat.upbeat.domain.interviewtest.repository;
+
+import com.upbeat.upbeat.domain.interviewtest.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}//JpaRepository<T, ID>에서 T는 관리할 엔티티 클래스의 타입, ID는 그 엔티티의 PK타입이다.

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/repository/QuestionRepository.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/repository/QuestionRepository.java
@@ -5,9 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query("SELECT DISTINCT q FROM Question q JOIN FETCH q.options")
-    List<Question> findAllDistinct(); // 중복 제거 + 연관 객체 Fetch
+    List<Question> findAllDistinct(); // 전체 조회용: 옵션까지 fetch
+
+    @Query("SELECT q FROM Question q JOIN FETCH q.options WHERE q.id = :id")
+    Optional<Question> findByIdWithOptions(Long id); // 단일 조회용: 옵션까지 fetch
 }

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/repository/ResultTypeRepository.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/repository/ResultTypeRepository.java
@@ -1,0 +1,7 @@
+package com.upbeat.upbeat.domain.interviewtest.repository;
+
+import com.upbeat.upbeat.domain.interviewtest.entity.ResultType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResultTypeRepository extends JpaRepository<ResultType, String> {
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/repository/UserAnswerRepository.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/repository/UserAnswerRepository.java
@@ -1,0 +1,10 @@
+package com.upbeat.upbeat.domain.interviewtest.repository;
+
+import com.upbeat.upbeat.domain.interviewtest.entity.UserAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+public interface UserAnswerRepository extends JpaRepository<UserAnswer, Long> {
+    List<UserAnswer> findByUserId(Long userId);
+    boolean existsByUserIdAndQuestionId(Long userId, Long questionId);
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/OptionService.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/OptionService.java
@@ -1,0 +1,29 @@
+package com.upbeat.upbeat.domain.interviewtest.service;
+
+import com.upbeat.upbeat.domain.interviewtest.dto.OptionResponseDto;
+import com.upbeat.upbeat.domain.interviewtest.entity.Option;
+import com.upbeat.upbeat.domain.interviewtest.repository.OptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor // final 필드 기반 생성자 자동 생성
+public class OptionService {
+
+    private final OptionRepository optionRepository;
+
+    public List<OptionResponseDto> getOptionsByQuestionId(Long questionId) {
+        List<Option> options = optionRepository.findByQuestionId(questionId);
+
+        return options.stream()
+                .map(opt -> new OptionResponseDto(
+                        opt.getId(),
+                        opt.getLabel(),
+                        opt.getContent(),
+                        opt.getTypeCode()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/QuestionService.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/QuestionService.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,19 +15,15 @@ public class QuestionService {
     private final QuestionRepository questionRepository;
 
     public List<QuestionResponseDto> getAllQuestions() {
-        List<Question> questions = questionRepository.findAllDistinct();  // 수정된 부분
+        List<Question> questions = questionRepository.findAllDistinct();
         return questions.stream()
                 .map(QuestionResponseDto::from)
                 .toList();
     }
-    /*
-    stream을 통해 변환처리를 위한 흐름 생성 -> map을 통해 각 질문을 DTO로 변환 ->collect를 통해 변환된 DTO들을 리스트로 묶음
-    ->List<QuestionResponseDto> 반환
-    */
-    public QuestionResponseDto getQuestionById(Long id) {
-        Question question = questionRepository.findById(id)
-                .orElseThrow(()->new IllegalArgumentException("해당 질문이 존재하지 않습니다: id = " +id));
 
+    public QuestionResponseDto getQuestionById(Long id) {
+        Question question = questionRepository.findByIdWithOptions(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 질문이 존재하지 않습니다: id = " + id));
         return QuestionResponseDto.from(question);
-    }//특정 질문 조회를 위한 api(추가 기능)
+    }
 }

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/QuestionService.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/QuestionService.java
@@ -1,0 +1,35 @@
+package com.upbeat.upbeat.domain.interviewtest.service;
+
+import com.upbeat.upbeat.domain.interviewtest.dto.QuestionResponseDto;
+import com.upbeat.upbeat.domain.interviewtest.entity.Question;
+import com.upbeat.upbeat.domain.interviewtest.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+
+    public List<QuestionResponseDto> getAllQuestions() {
+        List<Question> questions = questionRepository.findAll();
+
+        return questions.stream()
+                .map(QuestionResponseDto::from)
+                .collect(Collectors.toList());
+    }
+    /*
+    stream을 통해 변환처리를 위한 흐름 생성 -> map을 통해 각 질문을 DTO로 변환 ->collect를 통해 변환된 DTO들을 리스트로 묶음
+    ->List<QuestionResponseDto> 반환
+    */
+    public QuestionResponseDto getQuestionById(Long id) {
+        Question question = questionRepository.findById(id)
+                .orElseThrow(()->new IllegalArgumentException("해당 질문이 존재하지 않습니다: id = " +id));
+
+        return QuestionResponseDto.from(question);
+    }//특정 질문 조회를 위한 api(추가 기능)
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/ResultTypeService.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/ResultTypeService.java
@@ -1,0 +1,20 @@
+package com.upbeat.upbeat.domain.interviewtest.service;
+
+import com.upbeat.upbeat.domain.interviewtest.dto.ResultTypeResponseDto;
+import com.upbeat.upbeat.domain.interviewtest.entity.ResultType;
+import com.upbeat.upbeat.domain.interviewtest.repository.ResultTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ResultTypeService {
+
+    private final ResultTypeRepository resultTypeRepository;
+
+    public ResultTypeResponseDto getResultByTypeCode(String code) {
+        ResultType resultType = resultTypeRepository.findById(code)
+                .orElseThrow(() -> new IllegalArgumentException("해당 결과 유형이 없습니다: code = " + code));
+        return new ResultTypeResponseDto(resultType.getName(), resultType.getDescription());
+    }
+}

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/UserAnswerService.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/UserAnswerService.java
@@ -26,23 +26,26 @@ public class UserAnswerService {
     private final ResultTypeService resultTypeService;
 
     //사용자 응답 저장
-    public void saveUserAnswer(UserAnswerRequestDto dto) {
-        boolean alreadyExists = userAnswerRepository.existsByUserIdAndQuestionId(dto.getUserId(), dto.getQuestionId());
+    public UserAnswerResponseDto saveUserAnswer(UserAnswerRequestDto dto, Long userId) {
+        boolean alreadyExists = userAnswerRepository.existsByUserIdAndQuestionId(userId, dto.getQuestionId());
         if (alreadyExists) {
             throw new IllegalStateException("이미 해당 질문에 답변했습니다. 중복 저장은 불가능합니다.");
         }
-        Question question =  questionRepository.findById(dto.getQuestionId())
-                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 질문입니다."));
+
+        Question question = questionRepository.findById(dto.getQuestionId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 질문입니다."));
         Option option = optionRepository.findById(dto.getOptionId())
-                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 보기입니다."));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 보기입니다."));
 
         UserAnswer userAnswer = new UserAnswer();
-        userAnswer.setUserId(dto.getUserId());
+        userAnswer.setUserId(userId); // 🔥 dto.getUserId()는 절대 쓰지 않음
         userAnswer.setQuestion(question);
         userAnswer.setOption(option);
 
-        userAnswerRepository.save(userAnswer);
+        UserAnswer saved = userAnswerRepository.save(userAnswer);
+        return UserAnswerResponseDto.from(saved);
     }
+
     //사용자 응답 조회
     public List<UserAnswerResponseDto> getUserAnswerDtos(Long userId) {
         return userAnswerRepository.findByUserId(userId).stream()

--- a/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/UserAnswerService.java
+++ b/src/main/java/com/upbeat/upbeat/domain/interviewtest/service/UserAnswerService.java
@@ -1,0 +1,104 @@
+package com.upbeat.upbeat.domain.interviewtest.service;
+
+import com.upbeat.upbeat.domain.interviewtest.dto.ResultTypeResponseDto;
+import com.upbeat.upbeat.domain.interviewtest.dto.UserAnswerRequestDto;
+import com.upbeat.upbeat.domain.interviewtest.dto.UserAnswerResponseDto;
+import com.upbeat.upbeat.domain.interviewtest.entity.Option;
+import com.upbeat.upbeat.domain.interviewtest.entity.Question;
+import com.upbeat.upbeat.domain.interviewtest.entity.UserAnswer;
+import com.upbeat.upbeat.domain.interviewtest.repository.OptionRepository;
+import com.upbeat.upbeat.domain.interviewtest.repository.QuestionRepository;
+import com.upbeat.upbeat.domain.interviewtest.repository.UserAnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserAnswerService {
+    private final UserAnswerRepository userAnswerRepository;
+    private final QuestionRepository questionRepository;
+    private final OptionRepository optionRepository;
+    private final ResultTypeService resultTypeService;
+
+    //사용자 응답 저장
+    public void saveUserAnswer(UserAnswerRequestDto dto) {
+        boolean alreadyExists = userAnswerRepository.existsByUserIdAndQuestionId(dto.getUserId(), dto.getQuestionId());
+        if (alreadyExists) {
+            throw new IllegalStateException("이미 해당 질문에 답변했습니다. 중복 저장은 불가능합니다.");
+        }
+        Question question =  questionRepository.findById(dto.getQuestionId())
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 질문입니다."));
+        Option option = optionRepository.findById(dto.getOptionId())
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 보기입니다."));
+
+        UserAnswer userAnswer = new UserAnswer();
+        userAnswer.setUserId(dto.getUserId());
+        userAnswer.setQuestion(question);
+        userAnswer.setOption(option);
+
+        userAnswerRepository.save(userAnswer);
+    }
+    //사용자 응답 조회
+    public List<UserAnswerResponseDto> getUserAnswerDtos(Long userId) {
+        return userAnswerRepository.findByUserId(userId).stream()
+                .map(UserAnswerResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    public String calculateResultType(Long userId) {
+        List<UserAnswer> answers = userAnswerRepository.findByUserId(userId);
+        int aCount = 0;
+        int bCount = 0;
+        Map<Integer, String> answerMap = new HashMap<>();
+
+        for (UserAnswer ans : answers) {
+            String label = ans.getOption().getLabel();
+            if ("A".equals(label)) aCount++;
+            else if ("B".equals(label)) bCount++;
+            answerMap.put(ans.getQuestion().getId().intValue(), label);
+        }
+
+        if (aCount >= 9 && bCount <= 1) return "TYPE1";
+        if (bCount >= 9 && aCount <= 1) return "TYPE2";
+        if ((aCount >= 4 && bCount <= 6) &&
+                ("A".equals(answerMap.getOrDefault(3, "")) || "A".equals(answerMap.getOrDefault(6, ""))) &&
+                !( // TYPE4 조건 X
+                        "B".equals(answerMap.getOrDefault(2, "")) &&
+                                "B".equals(answerMap.getOrDefault(8, ""))
+                ) &&
+                !( // TYPE5 조건 X
+                        "A".equals(answerMap.getOrDefault(5, "")) ||
+                                "A".equals(answerMap.getOrDefault(10, ""))
+                )) {
+            return "TYPE3";
+        }
+
+        if ((aCount >= 4 && bCount <= 6) &&
+                "B".equals(answerMap.getOrDefault(2, "")) && "B".equals(answerMap.getOrDefault(8, "")))
+            return "TYPE4";
+
+        if ((aCount >= 4 && bCount <= 6) &&
+                ("A".equals(answerMap.getOrDefault(5, "")) || "A".equals(answerMap.getOrDefault(10, ""))))
+            return "TYPE5";
+
+        return "TYPE6";
+    }
+
+    public ResultTypeResponseDto getUserResultType(Long userId) {
+        String typeCode = calculateResultType(userId);
+        return resultTypeService.getResultByTypeCode(typeCode);
+    }
+    //url매핑으로 인해 새로 추가한 코드
+    public Map<String, String> getRedirectUrlByUserResult(Long userId) {
+        String typeCode = calculateResultType(userId);
+        String redirectUrl = "/results/" + typeCode.toLowerCase() + ".html";
+        Map<String, String> result = new HashMap<>();
+        result.put("redirectUrl", redirectUrl);
+        return result;
+    }
+}

--- a/src/main/java/com/upbeat/upbeat/initializer/DataInitializer.java
+++ b/src/main/java/com/upbeat/upbeat/initializer/DataInitializer.java
@@ -1,0 +1,93 @@
+package com.upbeat.upbeat.initializer;
+
+import com.upbeat.upbeat.domain.interviewtest.entity.Option;
+import com.upbeat.upbeat.domain.interviewtest.entity.Question;
+import com.upbeat.upbeat.domain.interviewtest.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final QuestionRepository questionRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        Question q1 = new Question();
+        q1.setQuestion("1. 자기소개 질문을 받았을 때 나는…");
+
+        Option o1 = new Option(null, "A", "두루뭉술하게 전체 인생 흐름을 말하게 된다", "TYPE1", q1);
+        Option o2 = new Option(null, "B", "직무와 관련된 키워드를 중심으로 간결히 말한다", "TYPE1", q1);
+
+        q1.setOptions(List.of(o1, o2));
+
+        questionRepository.save(q1);
+
+        Question q2 = new Question();
+        q2.setQuestion("2. 내가 경험을 설명할 때는…");
+        Option q2_a = new Option(null, "A", "멋져 보이는 단어로 꾸미는 편이다", "TYPE2", q2);
+        Option q2_b = new Option(null, "B", "구체적인 상황, 숫자, 결과를 강조한다", "TYPE2", q2);
+        q2.setOptions(List.of(q2_a, q2_b));
+        questionRepository.save(q2);
+
+        Question q3 = new Question();
+        q3.setQuestion("3. 압박 질문이 나왔을 때 나는…");
+        Option q3_a = new Option(null, "A", "순간 멘붕이 오고, 머릿속이 하얘진다", "TYPE3", q3);
+        Option q3_b = new Option(null, "B", "당황하더라도 일단 말하고 정리해간다", "TYPE3", q3);
+        q3.setOptions(List.of(q3_a, q3_b));
+        questionRepository.save(q3);
+
+        Question q4 = new Question();
+        q4.setQuestion("4. 마지막 질문 “하고 싶은 말?”이 나오면…");
+        Option q4_a = new Option(null, "A", "준비한 말을 꺼내다가도 어버버한다", "TYPE4", q4);
+        Option q4_b = new Option(null, "B", "핵심 한 줄로 인상을 남기려 한다", "TYPE4", q4);
+        q4.setOptions(List.of(q4_a, q4_b));
+        questionRepository.save(q4);
+
+        Question q5 = new Question();
+        q5.setQuestion("5. 나의 말버릇은…");
+        Option q5_a = new Option(null, "A", "“어… 음…” 같은 추임새가 자주 나온다", "TYPE5", q5);
+        Option q5_b = new Option(null, "B", "말을 시작할 땐 침착하게 정리된 문장으로 시작한다", "TYPE5", q5);
+        q5.setOptions(List.of(q5_a, q5_b));
+        questionRepository.save(q5);
+
+        Question q6 = new Question();
+        q6.setQuestion("6. 예상 못한 질문을 받았을 때 나는…");
+        Option q6_a = new Option(null, "A", "너무 솔직하거나 당황스런 말을 해버린 적 있다", "TYPE6", q6);
+        Option q6_b = new Option(null, "B", "돌려 말하거나 일단 맥락부터 찾으려 노력한다", "TYPE6", q6);
+        q6.setOptions(List.of(q6_a, q6_b));
+        questionRepository.save(q6);
+
+        Question q7 = new Question();
+        q7.setQuestion("7. 내가 말한 뒤에 가장 자주 드는 생각은…");
+        Option q7_a = new Option(null, "A", "‘내가 왜 그렇게 말했지?’", "TYPE7", q7);
+        Option q7_b = new Option(null, "B", "‘그래도 말은 이어갔네’", "TYPE7", q7);
+        q7.setOptions(List.of(q7_a, q7_b));
+        questionRepository.save(q7);
+
+        Question q8 = new Question();
+        q8.setQuestion("8. 면접 전에 나는…");
+        Option q8_a = new Option(null, "A", "전체 시나리오를 외우듯 준비한다", "TYPE8", q8);
+        Option q8_b = new Option(null, "B", "키워드 중심으로 말 흐름만 정리한다", "TYPE8", q8);
+        q8.setOptions(List.of(q8_a, q8_b));
+        questionRepository.save(q8);
+
+        Question q9 = new Question();
+        q9.setQuestion("9. 나는 보통 말을…");
+        Option q9_a = new Option(null, "A", "길게 늘어지게 하는 편이다", "TYPE9", q9);
+        Option q9_b = new Option(null, "B", "짧고 핵심 있게 말하려 한다", "TYPE9", q9);
+        q9.setOptions(List.of(q9_a, q9_b));
+        questionRepository.save(q9);
+
+        Question q10 = new Question();
+        q10.setQuestion("10. 나의 말투는…");
+        Option q10_a = new Option(null, "A", "방어적이고 자신 없어 보인다는 말을 들은 적 있다", "TYPE10", q10);
+        Option q10_b = new Option(null, "B", "침착하지만 건조하게 들릴 수 있다", "TYPE10", q10);
+        q10.setOptions(List.of(q10_a, q10_b));
+        questionRepository.save(q10);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: dev #test할때는 test로 바꾸면 에러 안남
+    active: dev #test할때는 test로 바꾸면 에러 안남 그 외에는 dev

--- a/src/test/java/com/upbeat/upbeat/UserAnswerServiceTest.java
+++ b/src/test/java/com/upbeat/upbeat/UserAnswerServiceTest.java
@@ -43,17 +43,20 @@ class UserAnswerServiceTest {
             Question question = questions.get(i);
             List<Option> options = question.getOptions();
 
-            int selectedIndex = abPattern.charAt(i) == 'A' ? 0 : 1;
-            Option selected = options.get(selectedIndex);
+            String desiredLabel = String.valueOf(abPattern.charAt(i));
+            Option selected = options.stream()
+                    .filter(o -> o.getLabel().equals(desiredLabel))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("해당 label 옵션이 없습니다: " + desiredLabel));
 
             UserAnswerRequestDto dto = new UserAnswerRequestDto();
-            //dto.setUserId(userId);
             dto.setQuestionId(question.getId());
             dto.setOptionId(selected.getId());
 
-            //userAnswerService.saveUserAnswer(dto);
+            userAnswerService.saveUserAnswer(dto, userId);
         }
     }
+
 
     @Test
     void TYPE1_두루뭉술_낭만가형() {

--- a/src/test/java/com/upbeat/upbeat/UserAnswerServiceTest.java
+++ b/src/test/java/com/upbeat/upbeat/UserAnswerServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -46,11 +47,11 @@ class UserAnswerServiceTest {
             Option selected = options.get(selectedIndex);
 
             UserAnswerRequestDto dto = new UserAnswerRequestDto();
-            dto.setUserId(userId);
+            //dto.setUserId(userId);
             dto.setQuestionId(question.getId());
             dto.setOptionId(selected.getId());
 
-            userAnswerService.saveUserAnswer(dto);
+            //userAnswerService.saveUserAnswer(dto);
         }
     }
 

--- a/src/test/java/com/upbeat/upbeat/UserAnswerServiceTest.java
+++ b/src/test/java/com/upbeat/upbeat/UserAnswerServiceTest.java
@@ -1,0 +1,102 @@
+package com.upbeat.upbeat;
+import com.upbeat.upbeat.domain.interviewtest.dto.UserAnswerRequestDto;
+import com.upbeat.upbeat.domain.interviewtest.entity.Option;
+import com.upbeat.upbeat.domain.interviewtest.entity.Question;
+import com.upbeat.upbeat.domain.interviewtest.repository.OptionRepository;
+import com.upbeat.upbeat.domain.interviewtest.repository.QuestionRepository;
+import com.upbeat.upbeat.domain.interviewtest.service.UserAnswerService;
+import lombok.Getter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Getter
+@SpringBootTest
+@Transactional
+class UserAnswerServiceTest {
+
+    @Autowired
+    private UserAnswerService userAnswerService;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private OptionRepository optionRepository;
+
+    private List<Question> questions;
+
+    @BeforeEach
+    void setup() {
+        questions = questionRepository.findAll();
+    }
+
+    private void submitAnswers(Long userId, String abPattern) {
+        for (int i = 0; i < 10; i++) {
+            Question question = questions.get(i);
+            List<Option> options = question.getOptions();
+
+            int selectedIndex = abPattern.charAt(i) == 'A' ? 0 : 1;
+            Option selected = options.get(selectedIndex);
+
+            UserAnswerRequestDto dto = new UserAnswerRequestDto();
+            dto.setUserId(userId);
+            dto.setQuestionId(question.getId());
+            dto.setOptionId(selected.getId());
+
+            userAnswerService.saveUserAnswer(dto);
+        }
+    }
+
+    @Test
+    void TYPE1_두루뭉술_낭만가형() {
+        submitAnswers(101L, "AAAAAAAAAA"); // A = 10
+        String result = userAnswerService.calculateResultType(101L);
+        assertThat(result).isEqualTo("TYPE1");
+    }
+
+    @Test
+    void TYPE2_과묵한_논리형() {
+        submitAnswers(102L, "BBBBBBBBBB"); // B = 10
+        String result = userAnswerService.calculateResultType(102L);
+        assertThat(result).isEqualTo("TYPE2");
+    }
+
+    @Test
+    void TYPE3_순간_멘붕러형() {
+        // Q3 = A, Q6 = A + 2개 이상 B among 2,8,5,10
+        submitAnswers(103L, "BAAABBABBB");
+        String result = userAnswerService.calculateResultType(103L);
+        assertThat(result).isEqualTo("TYPE3");
+    }
+
+    @Test
+    void TYPE4_시나리오_고정러형() {
+        // Q2, Q8 = B + 3,6,5,10 모두 B
+        submitAnswers(104L, "ABBABBABAB");
+        String result = userAnswerService.calculateResultType(104L);
+        assertThat(result).isEqualTo("TYPE4");
+    }
+
+    @Test
+    void TYPE5_방어적_자기검열러형() {
+        // Q5, Q10 = A + 2,3,6,8 모두 A
+        submitAnswers(105L, "AABAAABABA");
+        String result = userAnswerService.calculateResultType(105L);
+        assertThat(result).isEqualTo("TYPE5");
+    }
+
+    @Test
+    void TYPE6_혼합형() {
+        // 아무 조건도 충족 안 되는 중간값
+        submitAnswers(106L, "BABABBBBBB");
+        String result = userAnswerService.calculateResultType(106L);
+        assertThat(result).isEqualTo("TYPE6");
+    }
+}


### PR DESCRIPTION
면접체질 테스트에 대해 구현했습니다.
추가된 부분은 src부분에 대해서만 해당하며, 다음과 같습니다:
- main/java/com/upbeat/upbeat/domain부분에 interviewtest라는 디렉터리 생성
- main/java/com/upbeat/upbeat부분에 initializer폴더를 추가(질문 테스트 항목 저장용임)
- test부분에 useranswerServiceTest추가

5.26
- swagger 연동 및 테스트 완료
- api/questions/{id} 수정 완료